### PR TITLE
chore: add missing steps in major provider upgrade from v4 -> v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-# CDKTF prebuilt bindings for hashicorp/vault provider version 4.8.0
+# CDKTF prebuilt bindings for hashicorp/vault provider version 5.0.0
 
-This repo builds and publishes the [Terraform vault provider](https://registry.terraform.io/providers/hashicorp/vault/4.8.0/docs) bindings for [CDK for Terraform](https://cdk.tf).
+This repo builds and publishes the [Terraform vault provider](https://registry.terraform.io/providers/hashicorp/vault/5.0.0/docs) bindings for [CDK for Terraform](https://cdk.tf).
 
 ## Available Packages
 
@@ -63,7 +63,7 @@ This project is explicitly not tracking the Terraform vault provider version 1:1
 These are the upstream dependencies:
 
 - [CDK for Terraform](https://cdk.tf)
-- [Terraform vault provider](https://registry.terraform.io/providers/hashicorp/vault/4.8.0)
+- [Terraform vault provider](https://registry.terraform.io/providers/hashicorp/vault/5.0.0)
 - [Terraform Engine](https://terraform.io)
 
 If there are breaking changes (backward incompatible) in any of the above, the major version of this project will be bumped.

--- a/src/version.json
+++ b/src/version.json
@@ -1,3 +1,3 @@
 {
-  "registry.terraform.io/hashicorp/vault": "4.8.0"
+  "registry.terraform.io/hashicorp/vault": "5.0.0"
 }


### PR DESCRIPTION
For some reason, our automation around major provider upgrades no longer updates all the right places; it should increment the version in `src/version.json` and doesn't. It also doesn't upgrade the version in `package.json` which I ended up doing manually in #794. The README version automatically gets set based on the version in `version.json`, so that should be automatically updated once that file is correct.